### PR TITLE
Add spacing to code in readme files

### DIFF
--- a/src/page/page.scss
+++ b/src/page/page.scss
@@ -87,9 +87,7 @@
 
 .readme code,
 .readme .highlight {
-  padding: 0;
-  padding-top: 0.2em;
-  padding-bottom: 0.2em;
+  padding: 0.2em 0.4em 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
   background-color: rgba(0, 0, 0, 0.04);

--- a/tasks/page/makeReadme.js
+++ b/tasks/page/makeReadme.js
@@ -40,7 +40,7 @@ if (require.main !== module) {
       ),
       '$1raw$3'
     )
-    let markdown = contents
+    let markdown = addSpacing(contents)
     if (path.extname(readme).toLowerCase() === '.rst') {
       markdown = rst2mdown(contents)
     }
@@ -55,4 +55,8 @@ if (require.main !== module) {
 
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+}
+
+function addSpacing(string) {
+  return string.replace(/[^ `](`[^\`].*?`)/g, ' $1')
 }


### PR DESCRIPTION
There is some spacing issues with code when used in a readme and parsed into HTML.

From #170 
![image](https://user-images.githubusercontent.com/22715037/57032222-1be3de00-6c07-11e9-9550-a812f7a8a8b6.png)

This PR adds spacing when the inline markdown is used. Some testing: 

![Screenshot from 2019-05-01 11-13-59](https://user-images.githubusercontent.com/22715037/57032370-6d8c6880-6c07-11e9-8323-fcbe3dbc456e.png)

Fixes: #170 