### PR TITLE
Updated the README: Added inkscape dependency in Required Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Services used are:
 - [Ninja Build](https://github.com/ninja-build/ninja/releases) >= 1.5.1
 - [Yarn](https://yarnpkg.com/) to ensure the correct dependencies are installed
 - The rest of the dependencies can be retrieved via `yarn install`
+- Inkscape (See below for quickstart instructions for Ubuntu/Debian)
+
+### Inkscape Quickstart for Ubuntu/Debian
+
+`sudo apt-get update`
+`sudo apt-get install inkscape`
 
 ### Running a local dev server
 


### PR DESCRIPTION
Added inkscape dependency under 'Required' heading. Added quickstart instructions to get inkscape for Debian and Ubuntu. Fixes Issue #173 