### PR TITLE
Add multiple projects per repo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ gerbers: manufacture/gerbers-and-drills
 ```
 
 #### The multi field
+
+> NOTE: `multi` doesn't yet work with the [kitspace.org/submit](https://kitspace.org/submit) preview tool. See issue [#182](https://github.com/kitspace/kitspace/issues/182).
+
 Kitspace supports multiple projects in one repository with the `multi` field. When multiple projects exist, `multi` will always be the first field in the `kitspace.yaml`, with the paths to your projects folder nested underneath.
 
 ```

--- a/README.md
+++ b/README.md
@@ -126,14 +126,30 @@ Kitspace supports multiple projects in one repository with the `multi` field. Wh
 ```
 ├── kitspace.yaml
 ├── project_one
-│    ├── 1-click-bom.tsv
-│    └── gerbers
-├── project_two
-     ├── 1-click-bom.tsv
-     └── gerbers
+│   ├── 1-click-bom.tsv
+│   ├── README.md
+│   └── gerbers
+│       ├── example.cmp
+│       ├── example.drd
+│       ├── example.dri
+│        ...
+│       ├── example.stc
+│       └── example.sts
+└── project_two
+    ├── 1-click-bom.tsv
+    ├── README.md
+    └── gerbers
+        ├── example.cmp
+        ├── example.drd
+        ├── example.dri
+         ...
+        ├── example.stc
+        └── example.sts
 
 ```
+
 with `kitspace.yaml` containing:
+
 ```yaml
 multi:
     project_one:
@@ -144,6 +160,36 @@ multi:
         summary: Second project in a repository.
         color: red
         site: https://example-two.com
+```
+
+If you want to use custom paths for `bom` and `gerbers` then note that these are from the root of the repository. There is currently no way to change the path of the README.
+
+E.g.
+
+```
+├── kitspace.yaml
+├── manufacturing_outputs
+│   └── project_one_gerbers
+│       ├── example.cmp
+│       ├── example.drd
+│       ├── example.dri
+│        ...
+│       ├── example.stc
+│       └── example.sts
+├── project_one
+    ├── BOM.csv
+    └── README.md
+└── project_two
+    ├── README.md
+    ...
+
+```yaml
+multi:
+    project_one:
+        bom: project_one/bom.csv
+        gerbers: manufacturing_outputs/project_one_gerbers
+    project_two:
+      ...
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ multi:
         site: https://example-two.com
 ```
 
-If you want to use custom paths for `bom` and `gerbers` then note that these are from the root of the repository. There is currently no way to change the path of the README.
+If you want to use custom paths for `bom` and `gerbers` then note that these are from the root of the repository. There is currently no way to change the path of the README (see issue [#183](https://github.com/kitspace/kitspace/issues/183)).
 
 E.g.
 
@@ -186,7 +186,7 @@ E.g.
 ```yaml
 multi:
     project_one:
-        bom: project_one/bom.csv
+        bom: project_one/BOM.csv
         gerbers: manufacturing_outputs/project_one_gerbers
     project_two:
       ...

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ color: The solder resist color of the preview rendering. Can be one of:
        - yellow
 bom: A path to your 1-click-bom in case it isn't `1-click-bom.tsv`.
 gerbers: A path to your folder of gerbers in case it isn't `gerbers/`.
+multi: Identifier field only used if the repository contains multiple projects.
 
 ```
 Paths should be in UNIX style (i.e. use `/` not `\`) and relative to the root
@@ -116,6 +117,31 @@ bom: manufacture/advanced-example-BOM.tsv
 gerbers: manufacture/gerbers-and-drills
 ```
 
+#### The multi field
+Kitspace supports multiple projects in one repository with the `multi` field. When multiple projects exist, `multi` will always be the first field in the `kitspace.yaml`, with the paths to your projects folder nested underneath.
+
+```
+├── kitspace.yaml
+├── project_one
+│    ├── 1-click-bom.tsv
+│    └── gerbers
+├── project_two
+     ├── 1-click-bom.tsv
+     └── gerbers
+
+```
+with `kitspace.yaml` containing:
+```yaml
+multi:
+    project_one:
+        summary: First project in a repository.
+        color: blue
+        site: https://example-one.com
+    project_two:
+        summary: Second project in a repository.
+        color: red
+        site: https://example-two.com
+```
 
 ## Development
 

--- a/boards.txt
+++ b/boards.txt
@@ -61,3 +61,4 @@ https://github.com/ollyoid/ShenzhenPostcard
 https://gitlab.com/erigas/gnukey
 https://gitlab.com/alexander.kutschera/singingplants
 https://gitlab.com/xengi/darling
+https://github.com/kitspace-forks/hoverboard-breakout

--- a/boards.txt
+++ b/boards.txt
@@ -61,4 +61,3 @@ https://github.com/ollyoid/ShenzhenPostcard
 https://gitlab.com/erigas/gnukey
 https://gitlab.com/alexander.kutschera/singingplants
 https://gitlab.com/xengi/darling
-https://github.com/kitspace-forks/hoverboard-breakout

--- a/configure
+++ b/configure
@@ -148,7 +148,7 @@ boardFolders.forEach((folder, index) => {
 
   if (info.multi) {
     for (let project in info.multi) {
-      projectPath = `${folder}/${project}`
+      projectPath = path.join(folder, project)
       boardFolders.push(projectPath)
     }
     boardFolders.splice(index, 1)

--- a/configure
+++ b/configure
@@ -3,6 +3,8 @@ let config, uglifyjs
 const ninjaBuildGen = require('ninja-build-gen')
 const globule = require('globule')
 const path = require('path')
+const yaml = require('js-yaml')
+const fs = require('fs')
 
 if (process.argv[2] === 'production') {
   config = 'production'
@@ -126,7 +128,32 @@ for (var f of images) {
     .using('copy')
 }
 
-const boardFolders = globule.find('boards/*/*/*', {filter: 'isDirectory'})
+let boardFolders = globule.find('boards/*/*/*', {filter: 'isDirectory'})
+
+boardFolders.forEach((folder, index) => {
+  let info
+  let file
+  if (fs.existsSync(`${folder}/kitnic.yaml`)) {
+    file = fs.readFileSync(`${folder}/kitnic.yaml`)
+  } else if (fs.existsSync(`${folder}/kitspace.yaml`)) {
+    file = fs.readFileSync(`${folder}/kitspace.yaml`)
+  } else if (fs.existsSync(`${folder}/kitspace.yml`)) {
+    file = fs.readFileSync(`${folder}/kitspace.yml`)
+  }
+  if (file != null) {
+    info = yaml.safeLoad(file)
+  } else {
+    info = {}
+  }
+
+  if (info.multi) {
+    for (let project in info.multi) {
+      projectPath = `${folder}/${info.multi[project].path}`
+      boardFolders.push(projectPath)
+    }
+    boardFolders.splice(index, 1)
+  }
+})
 
 const jsSrc = globule.find(['src/**/*.js', 'src/**/*.jsx'])
 

--- a/configure
+++ b/configure
@@ -148,7 +148,7 @@ boardFolders.forEach((folder, index) => {
 
   if (info.multi) {
     for (let project in info.multi) {
-      projectPath = `${folder}/${info.multi[project].path}`
+      projectPath = `${folder}/${project}`
       boardFolders.push(projectPath)
     }
     boardFolders.splice(index, 1)

--- a/dev_registry.json
+++ b/dev_registry.json
@@ -10,5 +10,9 @@
   {
     "repo": "https://github.com/kitspace-forks/Bus_Pirate",
     "hash": "0ca376a0eedd116e3ffdbd5dfd5398a67fdba708"
+  },
+  {
+    "repo": "https://github.com/kitspace-forks/hoverboard-breakout",
+    "hash": "0ad61fa761b571e12159b51b310f5d8971eda384"
   }
 ]

--- a/dev_registry.json
+++ b/dev_registry.json
@@ -13,6 +13,6 @@
   },
   {
     "repo": "https://github.com/kitspace-forks/hoverboard-breakout",
-    "hash": "0ad61fa761b571e12159b51b310f5d8971eda384"
+    "hash": "3b5db21b48e9172c63d911aae6a6fa241e0060e4"
   }
 ]

--- a/src/index/board_card.jsx
+++ b/src/index/board_card.jsx
@@ -70,7 +70,7 @@ let BoardCard = React.createClass({
           <div className="title">
             {this.props.data.id
               .split('/')
-              .slice(2)
+              .slice(-1)
               .join(' / ')}
           </div>
           <div className="url">

--- a/src/page/page.jsx
+++ b/src/page/page.jsx
@@ -23,7 +23,7 @@ const Page = React.createClass({
   render() {
     const idText = info.id
       .split('/')
-      .slice(2)
+      .slice(-1)
       .join(' / ')
     const titleText = `${idText} on Kitspace`
     const subtitleText = info.id

--- a/tasks/makeBoardsJson.js
+++ b/tasks/makeBoardsJson.js
@@ -88,6 +88,8 @@ if (require.main !== module) {
 
     if (info.multi) {
       for (let project in info.multi) {
+        info.multi[project].path = project
+
         getBoardInfo(info.multi[project], folder)
       }
     } else {

--- a/tasks/makeBoardsJson.js
+++ b/tasks/makeBoardsJson.js
@@ -15,6 +15,28 @@ if (require.main !== module) {
     return {deps, targets, moduleDep}
   }
 } else {
+  const getBoardInfo = function(project, folder) {
+    let board = correctTypes(project)
+    let projectFolder = folder
+
+    if (project.path) {
+      projectFolder = projectFolder + '/' + project.path
+    }
+
+    board.id = path.relative(boardDir, projectFolder)
+
+    if (board.summary === '' && /^github.com/.test(board.id)) {
+      const ghInfo = getGithubInfo(board.id)
+      if (__guard__(ghInfo, x => x.description) != null) {
+        board.summary = ghInfo.description
+      } else {
+        console.warn(`WARNING: could not get GitHub description for ${folder}`)
+      }
+    }
+
+    boards.push(board)
+  }
+
   const getGithubInfo = function(id) {
     let text
     const url = `https://api.github.com/repos${id.replace(/^github.com/, '')}`
@@ -33,11 +55,13 @@ if (require.main !== module) {
       id: '',
       summary: ''
     }
+
     for (let prop in boardInfoWithEmpty) {
       if (boardInfo.hasOwnProperty(prop)) {
         boardInfoWithEmpty[prop] = String(boardInfo[prop])
       }
     }
+
     return boardInfoWithEmpty
   }
 
@@ -61,17 +85,14 @@ if (require.main !== module) {
     } else {
       info = {}
     }
-    info = correctTypes(info)
-    info.id = path.relative(boardDir, folder)
-    if (info.summary === '' && /^github.com/.test(info.id)) {
-      const ghInfo = getGithubInfo(info.id)
-      if (__guard__(ghInfo, x => x.description) != null) {
-        info.summary = ghInfo.description
-      } else {
-        console.warn(`WARNING: could not get GitHub description for ${folder}`)
+
+    if (info.multi) {
+      for (let project in info.multi) {
+        getBoardInfo(info.multi[project], folder)
       }
+    } else {
+      getBoardInfo(info, folder)
     }
-    boards.push(info)
   }
 
   const boardJson = fs.openSync(targets[0], 'w')

--- a/tasks/makeBoardsJson.js
+++ b/tasks/makeBoardsJson.js
@@ -20,7 +20,7 @@ if (require.main !== module) {
     let projectFolder = folder
 
     if (project.path) {
-      projectFolder = projectFolder + '/' + project.path
+      projectFolder = path.join(projectFolder, project.path)
     }
 
     board.id = path.relative(boardDir, projectFolder)

--- a/tasks/page/processBOM.js
+++ b/tasks/page/processBOM.js
@@ -11,30 +11,41 @@ const getPartinfo = require('../../src/get_partinfo.js')
 if (require.main !== module) {
   module.exports = function(config, folder) {
     let bom, file, info
-    let root = folder
+    let repoRootPath = folder
 
-    repoStructure = folder.split('/')
-    if (repoStructure.length > 4) {
-      root = repoStructure.slice(0, 4).join('/')
+    repoFolders = folder.split('/')
+    if (repoFolders.length > 4) {
+      repoRootPath = repoFolders.slice(0, 4).join('/')
+      projectFolder = repoFolders.splice(4).join('/')
     }
 
-    if (fs.existsSync(`${root}/kitnic.yaml`)) {
-      file = fs.readFileSync(`${root}/kitnic.yaml`)
-    } else if (fs.existsSync(`${root}/kitspace.yaml`)) {
-      file = fs.readFileSync(`${root}/kitspace.yaml`)
-    } else if (fs.existsSync(`${root}/kitspace.yml`)) {
-      file = fs.readFileSync(`${root}/kitspace.yml`)
+    if (fs.existsSync(`${repoRootPath}/kitnic.yaml`)) {
+      file = fs.readFileSync(`${repoRootPath}/kitnic.yaml`)
+    } else if (fs.existsSync(`${repoRootPath}/kitspace.yaml`)) {
+      file = fs.readFileSync(`${repoRootPath}/kitspace.yaml`)
+    } else if (fs.existsSync(`${repoRootPath}/kitspace.yml`)) {
+      file = fs.readFileSync(`${repoRootPath}/kitspace.yml`)
     }
     if (file != null) {
       info = yaml.safeLoad(file)
     } else {
       info = {}
     }
+
+    if (info.multi) {
+      for (let project in info.multi) {
+        if (project === projectFolder) {
+          info = info.multi[project]
+        }
+      }
+    }
+
     if (info.bom) {
-      bom = folder + '/' + info.bom
+      bom = repoRootPath + '/' + info.bom
     } else {
       bom = folder + '/1-click-bom.tsv'
     }
+
     const deps = ['build/.temp/boards.json', folder, bom]
     const targets = [
       `build/.temp/${folder}/info.json`,

--- a/tasks/page/processBOM.js
+++ b/tasks/page/processBOM.js
@@ -41,11 +41,11 @@ if (require.main !== module) {
         }
       }
     }
-    
+
     if (info.bom) {
-      bom = repoRootPath + '/' + info.bom
+      bom = path.join(repoRootPath, info.bom)
     } else {
-      bom = projectPath + '/1-click-bom.tsv'
+      bom = path.join(projectPath, '1-click-bom.tsv')
     }
 
     const deps = ['build/.temp/boards.json', folder, bom]

--- a/tasks/page/processBOM.js
+++ b/tasks/page/processBOM.js
@@ -11,12 +11,19 @@ const getPartinfo = require('../../src/get_partinfo.js')
 if (require.main !== module) {
   module.exports = function(config, folder) {
     let bom, file, info
-    if (fs.existsSync(`${folder}/kitnic.yaml`)) {
-      file = fs.readFileSync(`${folder}/kitnic.yaml`)
-    } else if (fs.existsSync(`${folder}/kitspace.yaml`)) {
-      file = fs.readFileSync(`${folder}/kitspace.yaml`)
-    } else if (fs.existsSync(`${folder}/kitspace.yml`)) {
-      file = fs.readFileSync(`${folder}/kitspace.yml`)
+    let root = folder
+
+    repoStructure = folder.split('/')
+    if (repoStructure.length > 4) {
+      root = repoStructure.slice(0, 4).join('/')
+    }
+
+    if (fs.existsSync(`${root}/kitnic.yaml`)) {
+      file = fs.readFileSync(`${root}/kitnic.yaml`)
+    } else if (fs.existsSync(`${root}/kitspace.yaml`)) {
+      file = fs.readFileSync(`${root}/kitspace.yaml`)
+    } else if (fs.existsSync(`${root}/kitspace.yml`)) {
+      file = fs.readFileSync(`${root}/kitspace.yml`)
     }
     if (file != null) {
       info = yaml.safeLoad(file)
@@ -52,12 +59,19 @@ if (require.main !== module) {
     }
   }, '')
 
-  if (fs.existsSync(`${folder}/kitnic.yaml`)) {
-    file = fs.readFileSync(`${folder}/kitnic.yaml`)
-  } else if (fs.existsSync(`${folder}/kitspace.yaml`)) {
-    file = fs.readFileSync(`${folder}/kitspace.yaml`)
-  } else if (fs.existsSync(`${folder}/kitspace.yml`)) {
-    file = fs.readFileSync(`${folder}/kitspace.yml`)
+  let root = folder
+
+  repoStructure = folder.split('/')
+  if (repoStructure.length > 4) {
+    root = repoStructure.slice(0, 4).join('/')
+  }
+
+  if (fs.existsSync(`${root}/kitnic.yaml`)) {
+    file = fs.readFileSync(`${root}/kitnic.yaml`)
+  } else if (fs.existsSync(`${root}/kitspace.yaml`)) {
+    file = fs.readFileSync(`${root}/kitspace.yaml`)
+  } else if (fs.existsSync(`${root}/kitspace.yml`)) {
+    file = fs.readFileSync(`${root}/kitspace.yml`)
   }
   if (file != null) {
     kitnicYaml = yaml.safeLoad(file)

--- a/tasks/page/processBOM.js
+++ b/tasks/page/processBOM.js
@@ -10,13 +10,15 @@ const getPartinfo = require('../../src/get_partinfo.js')
 
 if (require.main !== module) {
   module.exports = function(config, folder) {
-    let bom, file, info
-    let repoRootPath = folder
+    let bom, file, info, repoRootPath, projectPath
+    const repoFolders = folder.split('/')
 
-    repoFolders = folder.split('/')
     if (repoFolders.length > 4) {
       repoRootPath = repoFolders.slice(0, 4).join('/')
-      projectFolder = repoFolders.splice(4).join('/')
+      projectPath = repoFolders.splice(4).join('/')
+    } else {
+      repoRootPath = folder
+      projectPath = folder
     }
 
     if (fs.existsSync(`${repoRootPath}/kitnic.yaml`)) {
@@ -34,16 +36,16 @@ if (require.main !== module) {
 
     if (info.multi) {
       for (let project in info.multi) {
-        if (project === projectFolder) {
+        if (project === projectPath) {
           info = info.multi[project]
         }
       }
     }
-
+    
     if (info.bom) {
       bom = repoRootPath + '/' + info.bom
     } else {
-      bom = folder + '/1-click-bom.tsv'
+      bom = projectPath + '/1-click-bom.tsv'
     }
 
     const deps = ['build/.temp/boards.json', folder, bom]
@@ -54,7 +56,7 @@ if (require.main !== module) {
     return {deps, targets, moduleDep: false}
   }
 } else {
-  let file, kitnicYaml
+  let file, kitnicYaml, repoRootPath
   const {deps, targets} = utils.processArgs(process.argv)
   const [boardsJSON, folder, bomPath] = deps
   const [infoPath, outBomPath] = targets
@@ -70,19 +72,19 @@ if (require.main !== module) {
     }
   }, '')
 
-  let root = folder
-
-  repoStructure = folder.split('/')
-  if (repoStructure.length > 4) {
-    root = repoStructure.slice(0, 4).join('/')
+  repoFolders = folder.split('/')
+  if (repoFolders.length > 4) {
+    repoRootPath = repoFolders.slice(0, 4).join('/')
+  } else {
+    repoRootPath = folder
   }
 
-  if (fs.existsSync(`${root}/kitnic.yaml`)) {
-    file = fs.readFileSync(`${root}/kitnic.yaml`)
-  } else if (fs.existsSync(`${root}/kitspace.yaml`)) {
-    file = fs.readFileSync(`${root}/kitspace.yaml`)
-  } else if (fs.existsSync(`${root}/kitspace.yml`)) {
-    file = fs.readFileSync(`${root}/kitspace.yml`)
+  if (fs.existsSync(`${repoRootPath}/kitnic.yaml`)) {
+    file = fs.readFileSync(`${repoRootPath}/kitnic.yaml`)
+  } else if (fs.existsSync(`${repoRootPath}/kitspace.yaml`)) {
+    file = fs.readFileSync(`${repoRootPath}/kitspace.yaml`)
+  } else if (fs.existsSync(`${repoRootPath}/kitspace.yml`)) {
+    file = fs.readFileSync(`${repoRootPath}/kitspace.yml`)
   }
   if (file != null) {
     kitnicYaml = yaml.safeLoad(file)

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -13,20 +13,20 @@ if (require.main !== module) {
     let file
     let projectPath
     let gerbersPath
-    let root = folder
+    let repoRootPath = folder
 
-    repoStructure = folder.split('/')
-    if (repoStructure.length > 4) {
-      root = repoStructure.slice(0, 4).join('/')
-      projectPath = repoStructure.splice(4).join('/')
+    repoFolders = folder.split('/')
+    if (repoFolders.length > 4) {
+      repoRootPath = repoFolders.slice(0, 4).join('/')
+      projectPath = repoFolders.splice(4).join('/')
     }
 
-    if (fs.existsSync(`${root}/kitnic.yaml`)) {
-      file = fs.readFileSync(`${root}/kitnic.yaml`)
-    } else if (fs.existsSync(`${root}/kitspace.yaml`)) {
-      file = fs.readFileSync(`${root}/kitspace.yaml`)
-    } else if (fs.existsSync(`${root}/kitspace.yml`)) {
-      file = fs.readFileSync(`${root}/kitspace.yml`)
+    if (fs.existsSync(`${repoRootPath}/kitnic.yaml`)) {
+      file = fs.readFileSync(`${repoRootPath}/kitnic.yaml`)
+    } else if (fs.existsSync(`${repoRootPath}/kitspace.yaml`)) {
+      file = fs.readFileSync(`${repoRootPath}/kitspace.yaml`)
+    } else if (fs.existsSync(`${repoRootPath}/kitspace.yml`)) {
+      file = fs.readFileSync(`${repoRootPath}/kitspace.yml`)
     }
     const info = file == null ? {} : yaml.safeLoad(file)
     const files = globule

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -10,14 +10,15 @@ const gerberFiles = require('../../src/gerber_files')
 
 if (require.main !== module) {
   module.exports = function(config, folder) {
-    let file
-    let projectPath
-    let repoRootPath = folder
+    let file, projectPath, repoRootPath
 
     repoFolders = folder.split('/')
     if (repoFolders.length > 4) {
       repoRootPath = repoFolders.slice(0, 4).join('/')
       projectPath = repoFolders.splice(4).join('/')
+    } else {
+      repoRootPath = folder
+      projectPath = folder
     }
 
     if (fs.existsSync(`${repoRootPath}/kitnic.yaml`)) {
@@ -29,8 +30,8 @@ if (require.main !== module) {
     }
     let info = file == null ? {} : yaml.safeLoad(file)
     const files = globule
-      .find(`${folder}/**/*`)
-      .map(p => path.relative(folder, p))
+      .find(`${repoRootPath}/**/*`)
+      .map(p => path.relative(repoRootPath, p))
 
     if (info.multi) {
       for (let project in info.multi) {
@@ -39,12 +40,11 @@ if (require.main !== module) {
         }
       }
     }
-
     const gerbers = gerberFiles(files, info.gerbers).map(p =>
-      path.join(folder, p)
+      path.join(repoRootPath, p)
     )
     if (gerbers.length === 0) {
-      console.error(`No gerbers found for ${folder}.`)
+      console.error(`No gerbers found for ${repoRootPath}.`)
       process.exit(1)
     }
     const deps = [folder].concat(gerbers)

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -18,7 +18,6 @@ if (require.main !== module) {
       projectPath = repoFolders.splice(4).join('/')
     } else {
       repoRootPath = folder
-      projectPath = folder
     }
 
     if (fs.existsSync(`${repoRootPath}/kitnic.yaml`)) {
@@ -29,17 +28,21 @@ if (require.main !== module) {
       file = fs.readFileSync(`${repoRootPath}/kitspace.yml`)
     }
     let info = file == null ? {} : yaml.safeLoad(file)
-    const files = globule
-      .find(`${repoRootPath}/**/*`)
-      .map(p => path.relative(repoRootPath, p))
+    let gerberPath = `${repoRootPath}/**/*`
 
     if (info.multi) {
       for (let project in info.multi) {
         if (project === projectPath) {
           info = info.multi[project]
+          gerberPath = `${repoRootPath}/${projectPath}/**/*`
         }
       }
     }
+
+    const files = globule
+      .find(gerberPath)
+      .map(p => path.relative(repoRootPath, p))
+
     const gerbers = gerberFiles(files, info.gerbers).map(p =>
       path.join(repoRootPath, p)
     )

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -35,7 +35,7 @@ if (require.main !== module) {
 
     if (info.multi) {
       for (let project in info.multi) {
-        if (info.multi[project].path === projectPath) {
+        if (project === projectPath) {
           gerbersPath = info.multi[project].gerbers
         }
       }
@@ -134,7 +134,7 @@ if (require.main !== module) {
       info = yaml.safeLoad(file)
       if (info.multi) {
         for (let project in info.multi) {
-          if (info.multi[project].path === projectPath) {
+          if (project === projectPath) {
             color = info.multi[project].color
           }
         }

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -12,7 +12,6 @@ if (require.main !== module) {
   module.exports = function(config, folder) {
     let file
     let projectPath
-    let gerbersPath
     let repoRootPath = folder
 
     repoFolders = folder.split('/')
@@ -28,7 +27,7 @@ if (require.main !== module) {
     } else if (fs.existsSync(`${repoRootPath}/kitspace.yml`)) {
       file = fs.readFileSync(`${repoRootPath}/kitspace.yml`)
     }
-    const info = file == null ? {} : yaml.safeLoad(file)
+    let info = file == null ? {} : yaml.safeLoad(file)
     const files = globule
       .find(`${folder}/**/*`)
       .map(p => path.relative(folder, p))
@@ -36,14 +35,12 @@ if (require.main !== module) {
     if (info.multi) {
       for (let project in info.multi) {
         if (project === projectPath) {
-          gerbersPath = info.multi[project].gerbers
+          info = info.multi[project]
         }
       }
-    } else {
-      gerbersPath = info.gerbers
     }
 
-    const gerbers = gerberFiles(files, gerbersPath).map(p =>
+    const gerbers = gerberFiles(files, info.gerbers).map(p =>
       path.join(folder, p)
     )
     if (gerbers.length === 0) {

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -28,13 +28,13 @@ if (require.main !== module) {
       file = fs.readFileSync(`${repoRootPath}/kitspace.yml`)
     }
     let info = file == null ? {} : yaml.safeLoad(file)
-    let gerberPath = `${repoRootPath}/**/*`
+    let gerberPath = path.join(repoRootPath, '**', '*')
 
     if (info.multi) {
       for (let project in info.multi) {
         if (project === projectPath) {
           info = info.multi[project]
-          gerberPath = `${repoRootPath}/${projectPath}/**/*`
+          gerberPath = path.join(repoRootPath, projectPath, '**', '*')
         }
       }
     }

--- a/tasks/page/processGerbers.js
+++ b/tasks/page/processGerbers.js
@@ -34,7 +34,11 @@ if (require.main !== module) {
       for (let project in info.multi) {
         if (project === projectPath) {
           info = info.multi[project]
-          gerberPath = path.join(repoRootPath, projectPath, '**', '*')
+          if (info.gerbers) {
+            gerberPath = path.join(repoRootPath, info.gerbers, '*')
+          } else {
+            gerberPath = path.join(repoRootPath, projectPath, '**', '*')
+          }
         }
       }
     }


### PR DESCRIPTION
Got this working on dev, but probably needs some more testing.

In the local `boards` folder, I created a single repo folder with a single kitspace.yaml in the root folder, and two project folders:

![Screenshot from 2019-05-19 21-04-06](https://user-images.githubusercontent.com/22715037/57986800-be121b80-7a79-11e9-8f67-301d34963153.png)

Here is the kitspace.yaml

![Screenshot from 2019-05-19 21-06-00](https://user-images.githubusercontent.com/22715037/57986818-eef25080-7a79-11e9-93a6-7f0c5db37110.png)

The build:

![Screenshot from 2019-05-19 21-06-51](https://user-images.githubusercontent.com/22715037/57986829-0f220f80-7a7a-11e9-86b4-31bba2adef73.png)
![Screenshot from 2019-05-19 21-07-28](https://user-images.githubusercontent.com/22715037/57986839-35e04600-7a7a-11e9-9500-e79b2ab0cb33.png)
![Screenshot from 2019-05-19 21-07-46](https://user-images.githubusercontent.com/22715037/57986841-3aa4fa00-7a7a-11e9-89d1-cd09c225ffae.png)

