### PR TITLE
Replace README image paths with project paths for multi project repos

### DIFF
--- a/tasks/page/makeReadme.js
+++ b/tasks/page/makeReadme.js
@@ -45,8 +45,7 @@ if (require.main !== module) {
       markdown = contents
     }
 
-    if (info.repo.includes('github')) {
-      markdown = replaceImageUrls(markdown)
+    if (info.repo.includes('https://github.com')) {
       markdown = addSpacing(markdown)
       if (multiProjectPath) {
         markdown = correctMarkdownImagePaths(markdown, multiProjectPath)

--- a/tasks/page/makeReadme.js
+++ b/tasks/page/makeReadme.js
@@ -46,6 +46,7 @@ if (require.main !== module) {
     }
 
     if (info.repo.includes('https://github.com')) {
+      markdown = replaceBlobUrls(markdown)
       markdown = addSpacing(markdown)
       if (multiProjectPath) {
         markdown = correctMarkdownImagePaths(markdown, multiProjectPath)
@@ -65,20 +66,21 @@ function addSpacing(string) {
   return string.replace(/[^ `](`[^\`].*?`)/g, ' $1')
 }
 
-// replace blob image urls with raw image urls, they don't work outside of github
-function replaceImageUrls(string) {
-  const imageUrl = /(https:\/\/github\.com\/.*?\/)(blob)(\/master\/.*?.(:?png|jpeg|jpg|gif|bmp))/gi
+// replace blob file urls with raw file urls, they don't work outside of github
+function replaceBlobUrls(string) {
+  const imageUrl = /(https:\/\/github\.com\/.*?\/)(blob)(\/.*?\.)/gi
 
   return string.replace(imageUrl, '$1raw$3')
 }
 
+// add project path from root folder to images; required before being parsed by marky markdown
 function correctMarkdownImagePaths(string, projectPath) {
   const imagePath = /(!\[.*?]\()((?!https:\/\/).+?(\.png|\.jpg|\.gif|\.jpeg|\.bmp))/gi
 
-  return string.replace(imagePath, (_match, _$1, path) => {
+  return string.replace(imagePath, (_match, imgTag, path) => {
     const parts = path.split('/')
     const fileName = parts[parts.length - 1]
 
-    return `(/${projectPath}/${fileName}`
+    return `${imgTag}/${projectPath}/${fileName}`
   })
 }


### PR DESCRIPTION
README images not correctly getting processed when they are from a repository with multiple projects.

Corrected this by getting the image filenames and building the correct path using the project path in the Kitspace yaml.

My testing was limited, but it seems to be working for me while playing around with the dev environment projects.

fixes #193 