### PR TITLE
Cached builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ script:
   - bash keep_alive.sh &
   - export NODE_ENV=production
   - ./scripts/plug_versions
-  - ./scripts/get_boards production cached
-  - ./configure production cached
+  - ./scripts/get_boards production $CACHED_BUILD
+  - ./configure production $CACHED_BUILD
   - wget https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-linux.zip
   - unzip ninja-linux.zip
+  - if  [ "${CACHED_BUILD}" != "cached" ]; then ./ninja clean; fi
   - ./ninja -j 2 && cp registry.json build/ && ./scripts/deploy
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ script:
   - bash keep_alive.sh &
   - export NODE_ENV=production
   - ./scripts/plug_versions
-  - ./scripts/get_boards production
-  - ./configure production
+  - ./scripts/get_boards production cached
+  - ./configure production cached
   - wget https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-linux.zip
   - unzip ninja-linux.zip
-  - ./ninja -j 2 && ./scripts/deploy
+  - ./ninja -j 2 && cp registry.json build/ && ./scripts/deploy
+cache:
+  yarn: true
+  directories:
+    - ./build

--- a/configure
+++ b/configure
@@ -12,6 +12,8 @@ if (process.argv[2] === 'production') {
   config = 'dev'
 }
 
+const cached_build = process.argv[3] === 'cached'
+
 const ninja = ninjaBuildGen('1.5.1', 'build/')
 
 ninja.header(`#generated from ${path.basename(module.filename)} \
@@ -46,7 +48,7 @@ const requires = `-r ${dependencies.join(' -r ')}`
 
 let rule = ninja.rule('node-task')
 if (config === 'production') {
-  rule.run(`node -- $in -- ${config} $out`)
+  rule.run(`node -- $in -- ${config} ${cached_build} $out`)
 } else {
   //write to $dotd depfile in makefile format for ninja to keep track of deps
   rule
@@ -57,7 +59,7 @@ if (config === 'production') {
         && node -- $in -- ${config} $targetFiles`
     )
     .depfile("'$dotd'")
-    .description(`node -- $in -- ${config} $targetFiles`)
+    .description(`node -- $in -- ${config} ${cached_build} $targetFiles`)
 }
 
 rule = ninja.rule('browserify')
@@ -128,7 +130,29 @@ for (var f of images) {
     .using('copy')
 }
 
-const repositories = globule.find('boards/*/*/*', {filter: 'isDirectory'})
+let repositories = globule.find('boards/*/*/*', {filter: 'isDirectory'})
+
+if (cached_build) {
+  const previous_path = './build/registry.json'
+  let previous_registry
+  if (fs.existsSync(previous_path)) {
+    previous_registry = require(previous_path)
+  }
+  const new_registry = require('./registry.json')
+  if (previous_registry) {
+    repositories = []
+    const {repoToFolder} = require('./scripts/utils')
+    for (const project of new_registry) {
+      const previous = previous_registry.find(
+        p => p.repo === project.repo && p.hash === project.hash
+      )
+      if (!previous) {
+        repositories.push(repoToFolder(project.repo))
+      }
+    }
+  }
+}
+
 const boards = repositories.reduce((newBoards, folder) => {
   const [info, yamlPath] = getKitspaceYaml(folder)
   if (info.multi) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "http-server": "^0.9.0",
     "jsdom": "^9.4.2",
     "jszip": "^3.1.1",
+    "mkdirp": "^1.0.4",
     "mocha": "^3.4.2",
     "netlify-cli": "^2.47.0",
     "ninja-build-gen": "^0.2.1",

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -9,14 +9,12 @@ then
     exit 0
 elif  [ "${TRAVIS_BRANCH}" != "master" ]
 then
-    rm -rf build/.temp
     echo -e "User-agent: *\nDisallow: /\n" > build/robots.txt
     echo -e "${SSH_KEY}" > key-file
     chmod 600 key-file
     #replace all occurunces of / with .
     folder=${TRAVIS_BRANCH//\//.}
-    ssh -i key-file -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "ubuntu@preview.kitspace.org" "rm -rf preview/${folder}"
-    scp -i key-file -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r build "ubuntu@preview.kitspace.org:preview/${folder}"
+    rsync --archive --compress --update --delete --recursive -e 'ssh -i key-file -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' build/ "ubuntu@preview.kitspace.org:preview/${folder}/"
     rm -f key-file
 else
     rm -rf build/.temp

--- a/scripts/get_boards
+++ b/scripts/get_boards
@@ -12,13 +12,15 @@ if (process.argv[2] === 'production') {
 }
 
 if (process.argv[3] === 'cached') {
-  const cached_registry = JSON.parse(
-    fs.readFileSync('build/registry.json', 'utf8')
-  )
+  let cached_registry = []
+  if (fs.existsSync('build/registry.json')) {
+    cached_registry = JSON.parse(fs.readFileSync('build/registry.json', 'utf8'))
+  }
   registry = registry.filter(
-    project => !cached_registry.find(
-      p => p.repo === project.repo && p.hash === project.hash
-    )
+    project =>
+      !cached_registry.find(
+        p => p.repo === project.repo && p.hash === project.hash
+      )
   )
 }
 

--- a/scripts/get_boards
+++ b/scripts/get_boards
@@ -1,42 +1,53 @@
 #!/usr/bin/env node
-let registry;
-const fs = require('fs');
-const cp = require('child_process');
-const utils = require('./utils');
+const fs = require('fs')
+const cp = require('child_process')
+const utils = require('./utils')
+const mkdirp = require('mkdirp')
 
+let registry
 if (process.argv[2] === 'production') {
-    registry = JSON.parse(fs.readFileSync('registry.json', 'utf8'));
+  registry = JSON.parse(fs.readFileSync('registry.json', 'utf8'))
 } else {
-    registry = JSON.parse(fs.readFileSync('dev_registry.json', 'utf8'));
+  registry = JSON.parse(fs.readFileSync('dev_registry.json', 'utf8'))
 }
 
+if (process.argv[3] === 'cached') {
+  const cached_registry = JSON.parse(
+    fs.readFileSync('build/registry.json', 'utf8')
+  )
+  registry = registry.filter(
+    project => !cached_registry.find(
+      p => p.repo === project.repo && p.hash === project.hash
+    )
+  )
+}
 
-for (let {repo, hash} of registry) {
-    const folder = utils.repoToFolder(repo);
-    fs.exists(folder, (function(folder, repo, hash, exists) {
-        let cmd;
-        if (exists) {
-            cmd = `cd ${folder} && git checkout ${hash} \
+mkdirp.sync('boards/')
+registry.forEach(({repo, hash}) => {
+  const folder = utils.repoToFolder(repo)
+  const exists = fs.existsSync(folder)
+  let cmd
+  if (exists) {
+    cmd = `cd ${folder} && git checkout ${hash} \
 || git fetch --unshallow && git checkout ${hash} \
-|| git pull origin master && git checkout ${hash}`;
-            console.log(cmd);
-            return cp.exec(cmd, function(err, out){
-                if (err != null) {
-                    console.error(err);
-                    return process.exit(err.code);
-                }
-            });
-        } else {
-            cmd = `git clone --depth=1 ${repo} ${folder} \
+|| git pull origin master && git checkout ${hash}`
+    console.log(cmd)
+    return cp.exec(cmd, function(err, out) {
+      if (err != null) {
+        console.error(err)
+        return process.exit(err.code)
+      }
+    })
+  } else {
+    cmd = `git clone --depth=1 ${repo} ${folder} \
 && cd ${folder} && git checkout ${hash} \
-|| git fetch --unshallow && git checkout ${hash}`;
-            console.log(cmd);
-            return cp.exec(cmd, function(err, out){
-                if (err != null) {
-                    console.error(err);
-                    return process.exit(err.code);
-                }
-    });
-        }}).bind(undefined, folder, repo, hash)
-    );
-}
+|| git fetch --unshallow && git checkout ${hash}`
+    console.log(cmd)
+    return cp.exec(cmd, function(err, out) {
+      if (err != null) {
+        console.error(err)
+        return process.exit(err.code)
+      }
+    })
+  }
+})

--- a/src/page/board_showcase.jsx
+++ b/src/page/board_showcase.jsx
@@ -11,7 +11,6 @@ var BoardShowcase = React.createClass({
   },
   frontBoardView: function(e) {
     e.preventDefault()
-    console.log('here')
     this.setState({
       viewFrontBoard: true
     })

--- a/tasks/makeBoardsJson.js
+++ b/tasks/makeBoardsJson.js
@@ -4,6 +4,7 @@ const path = require('path')
 const globule = require('globule')
 const utils = require('./utils/utils')
 const cp = require('child_process')
+const {repoToFolder} = require('../scripts/utils')
 
 const boardDir = 'boards'
 
@@ -15,63 +16,36 @@ if (require.main !== module) {
     return {deps, targets, moduleDep}
   }
 } else {
-  const getBoardInfo = function(project, folder) {
-    let board = correctTypes(project)
-    let projectFolder = folder
-
-    if (project.path) {
-      projectFolder = path.join(projectFolder, project.path)
+  const {config, cached_build, deps, targets} = utils.processArgs(process.argv)
+  const registry = require('../registry.json')
+  let folders = registry.map(p => repoToFolder(p.repo))
+  let boards = []
+  if (cached_build) {
+    console.info({cached_build})
+    let new_folders = []
+    if (fs.existsSync('build/registry.json')) {
+      const cached_registry = require('../build/registry.json')
+      new_folders = registry
+        .filter(
+          project =>
+            !cached_registry.find(
+              p => p.repo === project.repo && p.hash === project.hash
+            )
+        )
+        .map(p => repoToFolder(p.repo))
     }
-
-    board.id = path.relative(boardDir, projectFolder)
-
-    if (board.summary === '' && /^github.com/.test(board.id)) {
-      const ghInfo = getGithubInfo(folder)
-      if (__guard__(ghInfo, x => x.description) != null) {
-        board.summary = ghInfo.description
-      } else {
-        console.warn(`WARNING: could not get GitHub description for ${folder}`)
-      }
+    if (fs.existsSync('build/.temp/boards.json')) {
+      boards = require('../build/.temp/boards.json')
     }
-
-    boards.push(board)
+    boards = boards.filter(x => {
+      return !new_folders.find(
+        folder => folder === x.fromMulti || folder === path.join('boards', x.id)
+      )
+    })
+    folders = new_folders
   }
 
- function getGithubInfo(folder) {
-    const id = folder.replace(/^boards\/github.com/, '')
-    let text
-    const url = `https://api.github.com/repos${id}`
-    //we use this avoid being rate-limited
-    if (process.env.GH_TOKEN != null) {
-      text = cp.execSync(`curl -u kasbah:${process.env.GH_TOKEN} ${url}`)
-    } else {
-      console.warn('Using un-authenticated access to GitHub API')
-      text = cp.execSync(`curl ${url}`)
-    }
-    return JSON.parse(text)
-  }
-
-  const correctTypes = function(boardInfo) {
-    const boardInfoWithEmpty = {
-      id: '',
-      summary: ''
-    }
-
-    for (let prop in boardInfoWithEmpty) {
-      if (boardInfo.hasOwnProperty(prop)) {
-        boardInfoWithEmpty[prop] = String(boardInfo[prop])
-      }
-    }
-
-    return boardInfoWithEmpty
-  }
-
-  const {config, deps, targets} = utils.processArgs(process.argv)
-  const boards = []
-  const folders = globule.find(`${boardDir}/*/*/*`, {filter: 'isDirectory'})
-  shuffleArray(folders)
-
-  for (let folder of folders) {
+  for (const folder of folders) {
     let info
     let file
     if (fs.existsSync(`${folder}/kitnic.yaml`)) {
@@ -90,11 +64,12 @@ if (require.main !== module) {
     if (info.multi) {
       for (let project in info.multi) {
         info.multi[project].path = project
-
-        getBoardInfo(info.multi[project], folder)
+        const board = getBoardInfo(info.multi[project], folder)
+        board.fromMulti = folder
+        boards.push(board)
       }
     } else {
-      getBoardInfo(info, folder)
+      boards.push(getBoardInfo(info, folder))
     }
   }
 
@@ -105,6 +80,56 @@ if (require.main !== module) {
       process.exit(1)
     }
   })
+}
+
+function getBoardInfo(project, folder) {
+  let board = correctTypes(project)
+  let projectFolder = folder
+
+  if (project.path) {
+    projectFolder = path.join(projectFolder, project.path)
+  }
+
+  board.id = path.relative(boardDir, projectFolder)
+
+  if (board.summary === '' && /^github.com/.test(board.id)) {
+    const ghInfo = getGithubInfo(folder)
+    if (__guard__(ghInfo, x => x.description) != null) {
+      board.summary = ghInfo.description
+    } else {
+      console.warn(`WARNING: could not get GitHub description for ${folder}`)
+    }
+  }
+  return board
+}
+
+function getGithubInfo(folder) {
+  const id = folder.replace(/^boards\/github.com/, '')
+  let text
+  const url = `https://api.github.com/repos${id}`
+  //we use this to avoid being rate-limited
+  if (process.env.GH_TOKEN != null) {
+    text = cp.execSync(`curl -u kasbah:${process.env.GH_TOKEN} ${url}`)
+  } else {
+    console.warn('Using un-authenticated access to GitHub API')
+    text = cp.execSync(`curl ${url}`)
+  }
+  return JSON.parse(text)
+}
+
+function correctTypes(boardInfo) {
+  const boardInfoWithEmpty = {
+    id: '',
+    summary: ''
+  }
+
+  for (let prop in boardInfoWithEmpty) {
+    if (boardInfo.hasOwnProperty(prop)) {
+      boardInfoWithEmpty[prop] = String(boardInfo[prop])
+    }
+  }
+
+  return boardInfoWithEmpty
 }
 
 function __guard__(value, transform) {

--- a/tasks/makeBoardsJson.js
+++ b/tasks/makeBoardsJson.js
@@ -37,6 +37,7 @@ if (require.main !== module) {
     if (fs.existsSync('build/.temp/boards.json')) {
       boards = require('../build/.temp/boards.json')
     }
+    // remove any boards that are being updated
     boards = boards.filter(x => {
       return !new_folders.find(
         folder => folder === x.fromMulti || folder === path.join('boards', x.id)

--- a/tasks/makeBoardsJson.js
+++ b/tasks/makeBoardsJson.js
@@ -45,6 +45,7 @@ if (require.main !== module) {
     folders = new_folders
   }
 
+  console.info({folders})
   for (const folder of folders) {
     let info
     let file

--- a/tasks/utils/utils.js
+++ b/tasks/utils/utils.js
@@ -16,8 +16,9 @@ exports.processArgs = function(argv) {
   const sepIndex = argv.indexOf('--')
   const deps = argv.slice(2, sepIndex - 1 + 1 || undefined)
   const config = process.argv[sepIndex + 1]
-  const targets = process.argv.slice(sepIndex + 2)
-  return {config, deps, targets}
+  const cached_build = process.argv[sepIndex + 2] === 'true'
+  const targets = process.argv.slice(sepIndex + 3)
+  return {config, cached_build, deps, targets}
 }
 
 exports.reactRender = function(jsx, html, output, router = false) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7383,6 +7383,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mocha@^3.4.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"


### PR DESCRIPTION
This adds a `cached` argument to some scripts that will check if anything has changed since the last time Travis cached the build output and only re-builds the projects pages that have. This cuts build times down from half an hour to a few minutes.