### PR TITLE
Lighten vendor.js

### DIFF
--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ let browserify = `browserify --extension='.jsx' --transform [ babelify \
     --presets [ react es2015 ] ]`
 
 if (config === 'dev') {
-  browserify += ' --debug'
+  browserify += ' --debug --full-paths'
 } else {
   browserify += ' -g uglifyify'
 }

--- a/configure
+++ b/configure
@@ -56,7 +56,12 @@ function isSubmitDependency(name) {
     'url',
     'whats-that-gerber',
     'whats-that-gerber',
-    'xml-element-string'
+    'xml-element-string',
+    // these ones are indirect dependencies of 1-click-bom that should
+    // only need to be used in /submit
+    'electro-grammar',
+    's-expression',
+    'xlsx'
   ]
 
   return dependencies.some(dependency => dependency === name)

--- a/configure
+++ b/configure
@@ -44,6 +44,7 @@ function isSubmitDependency(name) {
   const dependencies = [
     '1-click-bom',
     'github-url-to-object',
+    'html-to-react',
     'immutable',
     'js-yaml',
     'lodash.camelcase',
@@ -51,6 +52,7 @@ function isSubmitDependency(name) {
     'path',
     'pcb-stackup',
     'react-router',
+    'react-markdown',
     'redux',
     'redux-immutable',
     'rst2mdown',

--- a/configure
+++ b/configure
@@ -42,6 +42,7 @@ if (config === 'dev') {
 
 function isSubmitDependency(name) {
   const dependencies = [
+    '1-click-bom',
     'github-url-to-object',
     'immutable',
     'js-yaml',
@@ -56,12 +57,7 @@ function isSubmitDependency(name) {
     'url',
     'whats-that-gerber',
     'whats-that-gerber',
-    'xml-element-string',
-    // these ones are indirect dependencies of 1-click-bom that should
-    // only need to be used in /submit
-    'electro-grammar',
-    's-expression',
-    'xlsx'
+    'xml-element-string'
   ]
 
   return dependencies.some(dependency => dependency === name)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "license": "CPAL-1.0",
   "dependencies": {
     "1-click-bom": "https://github.com/kitspace/npm-1-click-bom#78df7bb0ebfbdb7beee99d13514b3737f010508f",
+    "1-click-bom-minimal": "https://github.com/kitspace/npm-1-click-bom-minimal",
     "babel-polyfill": "^6.13.0",
     "browser-version": "^1.0.0",
     "github-url-to-object": "^2.2.6",

--- a/src/buy_parts/buy_parts.jsx
+++ b/src/buy_parts/buy_parts.jsx
@@ -1,6 +1,6 @@
 const React = require('react')
 const semantic = require('semantic-ui-react')
-const oneClickBom = require('1-click-bom')
+const oneClickBom = require('1-click-bom-minimal')
 const ReactResponsive = require('react-responsive')
 const browserVersion = require('browser-version')
 

--- a/src/buy_parts/direct_stores.jsx
+++ b/src/buy_parts/direct_stores.jsx
@@ -1,9 +1,9 @@
 const React = require('react')
 const superagent = require('superagent')
 
-const digikey_data = require('1-click-bom/lib/data/digikey.json')
-const farnell_data = require('1-click-bom/lib/data/farnell.json')
-const countries_data = require('1-click-bom/lib/data/countries.json')
+const digikey_data = require('1-click-bom-minimal/lib/data/digikey.json')
+const farnell_data = require('1-click-bom-minimal/lib/data/farnell.json')
+const countries_data = require('1-click-bom-minimal/lib/data/countries.json')
 
 function getLocation(callback) {
   const used_country_codes = Object.keys(countries_data).map(key => {

--- a/src/submit/url_submit.jsx
+++ b/src/submit/url_submit.jsx
@@ -5,7 +5,8 @@ const camelCase = require('lodash.camelcase')
 const marky = require('marky-markdown')
 const url = require('url')
 const jsYaml = require('js-yaml')
-const htmlToReact = new new require('html-to-react').Parser(React)
+const HtmlToReactParser = require('html-to-react').Parser
+const htmlToReact = new HtmlToReactParser(React)
 const githubUrlToObject = require('github-url-to-object')
 const oneClickBOM = require('1-click-bom')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,10 +4,7 @@
 
 "1-click-bom-minimal@https://github.com/kitspace/npm-1-click-bom-minimal":
   version "1.3.1"
-  resolved "https://github.com/kitspace/npm-1-click-bom-minimal#a4d6504c67bb9ce453c04f4e19e1250f6a13c975"
-  dependencies:
-    s-expression "^3.0.3"
-    xlsx "^0.12.6"
+  resolved "https://github.com/kitspace/npm-1-click-bom-minimal#b174fec7a21fe1d6c9021ded42e85640f2c2244f"
 
 "1-click-bom@https://github.com/kitspace/npm-1-click-bom#78df7bb0ebfbdb7beee99d13514b3737f010508f":
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"1-click-bom-minimal@https://github.com/kitspace/npm-1-click-bom-minimal":
+  version "1.3.1"
+  resolved "https://github.com/kitspace/npm-1-click-bom-minimal#a4d6504c67bb9ce453c04f4e19e1250f6a13c975"
+  dependencies:
+    s-expression "^3.0.3"
+    xlsx "^0.12.6"
+
 "1-click-bom@https://github.com/kitspace/npm-1-click-bom#78df7bb0ebfbdb7beee99d13514b3737f010508f":
   version "1.3.1"
   resolved "https://github.com/kitspace/npm-1-click-bom#78df7bb0ebfbdb7beee99d13514b3737f010508f"
@@ -4799,7 +4806,7 @@ gaze@^1.0.0:
   dependencies:
     globule "^1.0.0"
 
-gerber-parser@^4.0.0-next.9, gerber-parser@^4.2.0:
+gerber-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/gerber-parser/-/gerber-parser-4.2.0.tgz#cd9fdee647b82a54a0cf716491d6e9ed0dd5d56b"
   integrity sha512-b9whFhx0lsqL4NwltaAIiOoW9q+RmI8ZiGytsTjvbCa0ltis5XIsmYABoL3d7SFm10UwIebWK4hoCcdBVN9G0g==
@@ -4811,7 +4818,7 @@ gerber-parser@^4.0.0-next.9, gerber-parser@^4.2.0:
     lodash.padstart "^4.6.1"
     readable-stream "^3.4.0"
 
-gerber-plotter@^4.0.0-next.13, gerber-plotter@^4.2.0:
+gerber-plotter@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/gerber-plotter/-/gerber-plotter-4.2.0.tgz#960b2f0ddf1c0eb49e36b1b73e70e0e8964b9fd7"
   integrity sha512-kNI/ybiP0Z+JZih2H/lquNUvIFBQsgh47Z2SHBgP/mw3IzEdevmB5CulcXISJ5G65BVLeUIAeEVHJmrap+cxTw==
@@ -4822,21 +4829,6 @@ gerber-plotter@^4.0.0-next.13, gerber-plotter@^4.2.0:
     lodash.isfinite "^3.3.2"
     lodash.isfunction "^3.0.9"
     readable-stream "^3.4.0"
-
-gerber-to-svg@4.0.0-next.13:
-  version "4.0.0-next.13"
-  resolved "https://registry.yarnpkg.com/gerber-to-svg/-/gerber-to-svg-4.0.0-next.13.tgz#11b6d477ad8e89ba05ccc05469f1e0ca2afccfa3"
-  integrity sha512-ydmvxmyJE8T9kCYrEfJtRwT5M0S0/9l9p33r2o7ExWA1dio1Zw4jf9w9UzmmpqEPhdkPJzoBQCoH//FjfmKtBQ==
-  dependencies:
-    "@tracespace/xml-id" "^4.0.0-next.13"
-    escape-html "^1.0.3"
-    gerber-parser "^4.0.0-next.9"
-    gerber-plotter "^4.0.0-next.13"
-    inherits "^2.0.1"
-    lodash.isfinite "^3.2.0"
-    lodash.isstring "^4.0.1"
-    readable-stream "^2.1.2"
-    xml-element-string "^1.0.0"
 
 gerber-to-svg@^4.0.0-next.13:
   version "4.2.0"
@@ -6816,7 +6808,7 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
-lodash.isfinite@^3.2.0, lodash.isfinite@^3.3.2:
+lodash.isfinite@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
   integrity sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=
@@ -6914,11 +6906,6 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
-
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash.transform@^4.6.0:
   version "4.6.0"
@@ -9101,7 +9088,7 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==


### PR DESCRIPTION
Splitting out a lighter [npm-1-click-bom-minimal](https://github.com/kitspace/npm-1-click-bom-minimal) with no dependencies and finding some more `/submit` only dependencies makes `vendor.js` weigh in at **854KB**. :tada:  It's live here: http://lighter-vendorjs.preview.kitspace.org/ let me know if you see anything broken. (@SDBowen)

Couldn't get `source-map-analyzer ` to give the correct filenames but `disc` works with some tweaking: https://cloud.monostable.co.uk/kitspace-disc.html 

Biggest wins now would be only importing only the css or only what we need from `semantic-ui-react` and getting rid of `lodash` somehow (I think also there because of `semantic-ui-react`). I think I should stop though since we are [starting a re-write](https://github.com/kitspace/kitspace-using-gitea) that will code-split properly. 