### PR TITLE
IBOM: Roughest of the rough first pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,20 @@ addons:
     packages:
       - inkscape
       - kicad
+      - xvfb
 script:
   - bash keep_alive.sh &
   - export NODE_ENV=production
+  - mkdir ~/.kicad_plugins
+  - pushd ~/.kicad_plugins ; wget https://github.com/openscopeproject/InteractiveHtmlBom/releases/download/v2.3/InteractiveHtmlBom.zip ; unzip InteractiveHtmlBom.zip ; rm InteractiveHtmlBom.zip ; popd
   - ./scripts/plug_versions
   - ./scripts/get_boards production $CACHED_BUILD
   - ./configure production $CACHED_BUILD
   - wget https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-linux.zip
   - unzip ninja-linux.zip
   - if  [ "${CACHED_BUILD}" != "cached" ]; then ./ninja clean; fi
+  - Xvfb :0 -screen 0 1024x768x24 > X.log 2>&1 &
+  - export DISPLAY=:0
   - ./ninja -j 2 && cp registry.json build/ && ./scripts/deploy
 cache:
   yarn: true

--- a/configure
+++ b/configure
@@ -416,7 +416,10 @@ globule.find('tasks/*.js').forEach(taskFile => {
 globule.find('tasks/page/*.js').forEach(taskFile => {
   const task = require(`./${path.dirname(taskFile)}/${path.basename(taskFile)}`)
   boards.forEach(board => {
-    addEdge(taskFile, task(config, board))
+    let t = task(config, board)
+    if (t.targets.length > 0) {
+      addEdge(taskFile, t)
+    }
   })
 })
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -7,14 +7,15 @@ set -e
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]
 then
     exit 0
-elif  [ "${TRAVIS_BRANCH}" != "master" ]
+elif  [ "${TRAVIS_BRANCH}" != "master" -o "${TRAVIS_REPO_SLUG}" != "kitspace/kitspace" ]
 then
     echo -e "User-agent: *\nDisallow: /\n" > build/robots.txt
     echo -e "${SSH_KEY}" > key-file
     chmod 600 key-file
     # replace all / with .
     folder=${TRAVIS_BRANCH//\//.}
-    rsync --archive --compress --update --delete --recursive -e 'ssh -i key-file -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' build/ "ubuntu@preview.kitspace.org:preview/${folder}/"
+    UPLOAD_DESTINATION=${UPLOAD_DESTINATION:-ubuntu@preview.kitspace.org:-preview/${folder}/}
+    rsync --archive --compress --update --delete --recursive -e 'ssh -i key-file -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' build/ "${UPLOAD_DESTINATION}"
     rm -f key-file
 else
     mv build/.temp .

--- a/src/page/interactive_bom.jsx
+++ b/src/page/interactive_bom.jsx
@@ -1,0 +1,35 @@
+const React = require('react')
+const semantic = require('semantic-ui-react')
+const ReactResponsive = require('react-responsive')
+
+const {folder} = require('../zip-info.json')
+const ibomUrl = `https://kitspace.org/${folder}/interactive_bom.html`
+
+let InteractiveBOM = React.createClass({
+  render() {
+    return (
+      <ReactResponsive
+        query={
+        '(max-width: 920px)' // XXX if you change this change it in the .scss too!
+        }
+      >
+        {matches => (
+          <div className="InteractiveBOMMenu">
+            <semantic.Menu stackable={matches} compact borderless>
+              <div className="InteractiveBOMMenu__container">
+                <div className="InteractiveBOMMenu__link">
+                  <semantic.Menu.Item as="a" href="interactive_bom.html">
+                    <semantic.Icon size="big" name="columns" />
+                    Interactive BOM
+                  </semantic.Menu.Item>
+                </div>
+              </div>
+            </semantic.Menu>
+          </div>
+        )}
+      </ReactResponsive>
+    )
+  }
+})
+
+module.exports = InteractiveBOM

--- a/src/page/interactive_bom.scss
+++ b/src/page/interactive_bom.scss
@@ -1,0 +1,62 @@
+@import '../colors';
+@import '../common';
+
+.InteractiveBOMMenu {
+  padding: 16px 0;
+  margin-bottom: 20px;
+
+  .ui.borderless {
+    width: 100%;
+    border: 0px;
+    box-shadow: 0 0 0 0;
+  }
+
+  &__container {
+    display: flex;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  &__link {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: flex-start;
+  }
+
+  i {
+    padding-right: 5px;
+  }
+
+  img {
+    min-width: 100px;
+  }
+
+  //XXX if you change this change it in the .jsx too!
+  @media (max-width: 920px) {
+    .ui.menu {
+      width: 100%;
+    }
+
+    &__container {
+      flex-direction: column;
+      justify-content: center;
+    }
+  }
+
+  a.item {
+    margin-right: 10px !important;
+    margin-left: 10px !important;
+    display: flex !important;
+    justify-content: center !important;
+  }
+
+  div.ui.floating.label {
+    top: 2.5em !important;
+    left: 95% !important;
+  }
+
+  div.ui.label {
+    background-color: transparent !important;
+  }
+}

--- a/src/page/page.jsx
+++ b/src/page/page.jsx
@@ -8,6 +8,7 @@ const InfoBar = require('./info_bar')
 const TitleBar = require('../title_bar')
 const FadeImage = require('../fade_image')
 const BuyParts = require('../buy_parts/buy_parts')
+const InteractiveBOM = require('./interactive_bom')
 const Readme = require('../readme')
 const semantic = require('semantic-ui-react')
 
@@ -60,6 +61,7 @@ const Page = React.createClass({
               <FadeImage src="images/bottom.svg" />
             </BoardShowcase>
             <OrderPcbs />
+            {info.has_interactive_bom && <InteractiveBOM />}
             <BuyParts lines={info.bom.lines} parts={info.bom.parts} />
             <div className="readme-container">
               <Readme />

--- a/src/page/page.scss
+++ b/src/page/page.scss
@@ -4,6 +4,7 @@
 @import '../buy_parts/buy_parts';
 @import 'board_showcase';
 @import 'order_pcbs';
+@import 'interactive_bom';
 
 .disabledSite {
   color: $gray;

--- a/tasks/page/processBOM.js
+++ b/tasks/page/processBOM.js
@@ -17,12 +17,26 @@ if (require.main !== module) {
     } else {
       bom = path.join(boardInfo.boardPath, '1-click-bom.tsv')
     }
-    const deps = [
+    let kicadPcbFile
+    if (
+      boardInfo.eda &&
+      boardInfo.eda.type === 'kicad' &&
+      boardInfo.eda.pcb != null
+    ) {
+      kicadPcbFile = path.join(boardInfo.repoPath, boardInfo.eda.pcb)
+    } else if (boardInfo.eda == null) {
+      const kicadPcbPattern = path.join(boardInfo.boardPath, '**/*.kicad_pcb')
+      kicadPcbFile = globule.find(kicadPcbPattern)[0]
+    }
+    let deps = [
       'build/.temp/boards.json',
       boardInfo.repoPath,
       bom,
       boardInfo.yamlPath
     ]
+    if (kicadPcbFile != null) {
+      deps.push(kicadPcbFile)
+    }
     const targets = [
       `build/.temp/${boardInfo.boardPath}/info.json`,
       `build/${boardInfo.boardPath}/1-click-BOM.tsv`
@@ -89,6 +103,8 @@ if (require.main !== module) {
   })
   repo = repo.split('\t')[1].split(' ')[0]
   info.repo = repo
+
+  info.has_interactive_bom = deps.some((d) => d.endsWith('.kicad_pcb'))
 
   getPartinfo(info.bom.lines).then(parts => {
     info.bom.parts = parts

--- a/tasks/page/processIBOM.js
+++ b/tasks/page/processIBOM.js
@@ -1,0 +1,42 @@
+const fs = require('fs')
+const globule = require('globule')
+const path = require('path')
+const utils = require('../utils/utils')
+const cp = require('child_process')
+
+if (require.main !== module) {
+  module.exports = function(config, boardInfo) {
+    let kicadPcbFile
+    if (
+      boardInfo.eda &&
+      boardInfo.eda.type === 'kicad' &&
+      boardInfo.eda.pcb != null
+    ) {
+      kicadPcbFile = path.join(boardInfo.repoPath, boardInfo.eda.pcb)
+    } else if (boardInfo.eda == null) {
+      const kicadPcbPattern = path.join(boardInfo.boardPath, '**/*.kicad_pcb')
+      kicadPcbFile = globule.find(kicadPcbPattern)[0]
+    }
+    if (kicadPcbFile == null) {
+      return {deps: [], targets: [], moduleDep: false};
+    }
+    const deps = [kicadPcbFile]
+    const buildFolder = boardInfo.boardPath.replace('boards', 'build/boards')
+    const targets = [
+      `${buildFolder}/interactive_bom.html`
+    ]
+    return {deps, targets, moduleDep: false}
+  }
+} else {
+  const {config, deps, targets} = utils.processArgs(process.argv)
+  let kicadPcbFile = deps[0];
+  let ibom = targets[0];
+  const run_ibom = path.join(__dirname, 'run_ibom')
+  cp.execSync(`${run_ibom} ${kicadPcbFile} ${ibom}`)
+}
+
+function __guard__(value, transform) {
+  return typeof value !== 'undefined' && value !== null
+    ? transform(value)
+    : undefined
+}

--- a/tasks/page/run_ibom
+++ b/tasks/page/run_ibom
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+import os
+import os.path
+
+kicad_file = sys.argv[1]
+ibom_file = sys.argv[2]
+
+IBOM = "~/.kicad_plugins/InteractiveHtmlBom/generate_interactive_bom.py"
+IBOM_SCRIPT = os.path.expanduser(IBOM)
+
+destdir = os.path.abspath(os.path.dirname(ibom_file))
+
+os.chdir(os.path.dirname(kicad_file))
+
+cmd = ["python", IBOM_SCRIPT,
+       "--dest-dir", destdir,
+       "--name-format", "interactive_bom",
+       "--no-browser",
+       os.path.basename(kicad_file)]
+subprocess.call(cmd)


### PR DESCRIPTION
**WIP PR FOR DISCUSSION. DO NOT MERGE.**

Will eventually fix #274.

 - No customisation of look of IBOM pages
 - Fairly messy additions to build system

But it does work: boards that have a KiCad PCB file in them have an interactive BOM built and linked from the board page. To build locally you need to have `InteractiveHtmlBom` installed in `~/.kicad_plugins`.

(There are also some changes in this branch to help with running Travis on forks of the main kitspace repo.)