### PR TITLE
Add Linux PCB badge

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -93,3 +93,4 @@ https://github.com/joeycastillo/The-Open-Book
 https://github.com/BadenLab/LED-Zappelin
 https://github.com/BadenLab/Openspritzer
 https://github.com/Sussex-Neuroscience/pmt-combiner
+https://github.com/Chromico/linux-penguin-PCB-badge


### PR DESCRIPTION
The project does not have a BOM at it's mostly a PCB and the brooch is optional.