### PR TITLE
Update URL for Open-Gamma-Project/MicroFC-SiPM-Carrier-Board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,4 +1,4 @@
-https://github.com/Open-Gamma-Project/SiPM-Carrier-Board
+https://github.com/Open-Gamma-Project/MicroFC-SiPM-Carrier-Board
 https://github.com/Open-Gamma-Project/Open-Gamma-Detector
 https://github.com/kammce/SJTwo
 https://github.com/mattvenn/esp8266-breakout

--- a/src/_redirects
+++ b/src/_redirects
@@ -15,3 +15,4 @@
 /boards/gitlab.com/openflexure/openflexure-constant-current-illumination/ /boards/gitlab.com/openflexure/openflexure-constant-current-illumination/ofm_cc_illumination_single
 /boards/github.com/beehive-org/beehive/boards/peltier https://github.com/BeeHive-org/BeeHive/tree/master/hardware/archive/peltier
 /boards/github.com/jan--henrik/* /boards/github.com/jana-marie/:splat
+/boards/github.com/Open-Gamma-Project/SiPM-Carrier-Board /boards/github.com/Open-Gamma-Project/MicroFC-SiPM-Carrier-Board


### PR DESCRIPTION
Just renamed the repo and just to be sure updated the URL here for kitspace