### PR TITLE
add rrf_rpi_skr_adapter

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -138,5 +138,6 @@ https://github.com/balthazar-space/Unifying-PCB
 https://github.com/bschwind/key-ripper
 https://github.com/taylorconor/threeboard
 https://gitlab.com/salfter/rc2014-compat
+https://gitlab.com/salfter/rrf_rpi_skr_adapter
 https://github.com/rosmo-robot/micro-bot
 https://github.com/MaxZimmer/Spikeling-V2


### PR DESCRIPTION
This is a simple adapter to set up an SPI connection between a Bigtreetech SKR or SKR 3D-printer control board and a Raspberry Pi to enable the use of the TeamGloomy fork of ReprapFirmware.