### PR TITLE
Update OpenGammaProject name

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,7 +1,7 @@
-https://github.com/Open-Gamma-Project/Mini-SiD
-https://github.com/Open-Gamma-Project/AFBR-SiPM-Carrier-Board
-https://github.com/Open-Gamma-Project/MicroFC-SiPM-Carrier-Board
-https://github.com/Open-Gamma-Project/Open-Gamma-Detector
+https://github.com/OpenGammaProject/Mini-SiD
+https://github.com/OpenGammaProject/AFBR-SiPM-Carrier-Board
+https://github.com/OpenGammaProject/MicroFC-SiPM-Carrier-Board
+https://github.com/OpenGammaProject/Open-Gamma-Detector
 https://github.com/kammce/SJTwo
 https://github.com/mattvenn/esp8266-breakout
 https://github.com/kitspace-forks/arduino-uno

--- a/src/_redirects
+++ b/src/_redirects
@@ -16,5 +16,6 @@
 /boards/gitlab.com/openflexure/openflexure-constant-current-illumination/ /boards/gitlab.com/openflexure/openflexure-constant-current-illumination/ofm_cc_illumination_single
 /boards/github.com/beehive-org/beehive/boards/peltier https://github.com/BeeHive-org/BeeHive/tree/master/hardware/archive/peltier
 /boards/github.com/jan--henrik/* /boards/github.com/jana-marie/:splat
-/boards/github.com/Open-Gamma-Project/SiPM-Carrier-Board/ /boards/github.com/open-gamma-project/microfc-sipm-carrier-board/
-/boards/github.com/open-gamma-project/sipm-carrier-board/ /boards/github.com/open-gamma-project/microfc-sipm-carrier-board/
+/boards/github.com/Open-Gamma-Project/SiPM-Carrier-Board/ /boards/github.com/opengammaproject/microfc-sipm-carrier-board/
+/boards/github.com/open-gamma-project/sipm-carrier-board/ /boards/github.com/opengammaproject/microfc-sipm-carrier-board/
+/boards/github.com/open-gamma-project/* /boards/github.com/opengammaproject/:splat


### PR DESCRIPTION
Changed the org's username from Open-Gamma-Project to OpenGammaProject. GH _should_ redirect in theory, but use the newer links just in case someone registered Open-Gamma-Project now and somehow hijacked the repos or something.

Hope this fixes everything. Do the Kitspace links get changed from `https://kitspace.org/boards/github.com/Open-Gamma-Project/Mini-SiD/` to `https://kitspace.org/boards/github.com/OpenGammaProject/Mini-SiD/` automatically?