### PR TITLE
Add MLAB USBI2C01

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -142,5 +142,6 @@ https://gitlab.com/salfter/rc2014-compat
 https://gitlab.com/salfter/rrf_rpi_skr_adapter
 https://github.com/rosmo-robot/micro-bot
 https://github.com/MaxZimmer/Spikeling-V2
+https://github.com/mlab-modules/USBI2C01
 https://github.com/dtomcat/ArdPromSD
 https://github.com/rbaron/b-parasite


### PR DESCRIPTION
Hi, I want to add some modules from the [MLAB.cz system](https://github.com/mlab-modules). 
The first one as an example is the [USB to I2C converter](https://github.com/mlab-modules/USBI2C01). 
We made attempt to automatically generate the `kitspace.yaml` from data contained in the repository. Therefore we could add many MLAB open-source modules. But that seems to be difficult by using these pull-requests. Is there some plan for something like API to interact with the design's repository registration? 