### PR TITLE
Revert "Pin glasgow to revC1"

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -12,10 +12,6 @@
     "hash": "84dc2b08f0df32772ac58f7f7f127f32161bda14"
   },
   {
-    "repo": "https://github.com/GlasgowEmbedded/glasgow",
-    "hash": "d7e5a870dab4f527bc41b01ac16fb4b118d997cd"
-  },
-  {
     "repo": "https://github.com/kitspace/ruler",
     "hash": "2af1eef430b2382d22d3c8a95abe18ccc1ee5dc7"
   },


### PR DESCRIPTION
This reverts commit 7e6a4e882c1e600e82bb83bc6850f153326841a2.

Fixes GlasgowEmbedded/glasgow#570